### PR TITLE
[rpm] add logic to ensure 0555 permissions on /usr/bin for rhel >= 6

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -321,13 +321,22 @@ module Omnibus
     end
 
     #
+    # Returns true if platform_family matches rhel and major version is 6 or above
+    #
+    # @return [TrueClass,FalseClass]
+    #
+    def rhel_6_or_newer?
+      Ohai["platform_family"] == "rhel" && (Gem::Version.new(Ohai["platform_version"]) >= Gem::Version("6"))
+    end
+
+    #
     # Mark filesystem directories with ownership and permissions specified in the filesystem package
     # https://git.fedorahosted.org/cgit/filesystem.git/plain/filesystem.spec
     #
     # @return [String]
     #
     def mark_filesystem_directories(fsdir)
-      if fsdir.eql?("/") || fsdir.eql?("/usr/lib") || fsdir.eql?("/usr/share/empty")
+      if fsdir.eql?("/") || fsdir.eql?("/usr/lib") || fsdir.eql?("/usr/share/empty") || (fsdir.eql?("/usr/bin") && rhel_6_or_newer?)
         return "%dir %attr(0555,root,root) #{fsdir}"
       elsif filesystem_directories.include?(fsdir)
         return "%dir %attr(0755,root,root) #{fsdir}"


### PR DESCRIPTION
### Description

We've found that RHEL 5 ships with mode 0755 on /usr/bin, while RHEL 6
and 7 ship with mode 0555. As a result, installing packages built for RHEL 6 or
7 contain files destined for /usr/bin will fail thusly:

```
file /usr/bin from install of sensu-1:0.27.0.beta.2-1.el7.x86_64 conflicts with file from package filesystem-3.2-20.el7.x86_64
```

An solution solution would be to implement an approach which considers the
permissions specified by the system's `filesystem` package at build time (see
https://github.com/chef/omnibus/pull/666#issuecomment-209597222). For now, we'll
kick the can down the road a bit.

Signed-off-by: Cameron Johnston <cameron@rootdown.net>